### PR TITLE
Add link for ProjectDetailPage

### DIFF
--- a/src/components/MoreSupport.jsx
+++ b/src/components/MoreSupport.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import UpcomingProjects from "./UpcomingProjects";
 
 // props for number of girls entering whatever grade
@@ -6,7 +7,9 @@ export default function MoreSupport() {
   const numOfCards = 10;
 
   const repeatedCards = Array.from({ length: numOfCards }, (item, index) => (
-    <UpcomingProjects className="" key={index} />
+    <Link to="/project" >
+      <UpcomingProjects className="" key={index} />
+    </Link>
   ));
 
   const buttonTypes = [


### PR DESCRIPTION
The link for the ProjectDetailPage from MoreSupport.jsx accidentally got removed, this adds it back in.